### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # django-unslashed 
 
-[![Version](https://pypip.in/version/django-unslashed/badge.png)](https://pypi.python.org/pypi/django-unslashed/) [![Build Status](https://travis-ci.org/dghubble/django-unslashed.png)](https://travis-ci.org/dghubble/django-unslashed) [![Downloads](https://pypip.in/download/django-unslashed/badge.png)](https://pypi.python.org/pypi/django-unslashed/) [![License](https://pypip.in/license/django-unslashed/badge.png)](https://pypi.python.org/pypi/django-unslashed/)
+[![Version](https://img.shields.io/pypi/v/django-unslashed.svg)](https://pypi.python.org/pypi/django-unslashed/) [![Build Status](https://travis-ci.org/dghubble/django-unslashed.png)](https://travis-ci.org/dghubble/django-unslashed) [![Downloads](https://img.shields.io/pypi/dm/django-unslashed.svg)](https://pypi.python.org/pypi/django-unslashed/) [![License](https://img.shields.io/pypi/l/django-unslashed.svg)](https://pypi.python.org/pypi/django-unslashed/)
 
 This middleware provides the inverse of the Django CommonMiddleware `APPEND_SLASH` feature. It can automatically remove trailing URL slashes and 301 redirect to the non-slash-terminated URL. This behavior is performed if the initial URL ends in a slash and is invalid, removing the trailing slash produces a valid URL, and `REMOVE_SLASH` is set to True. Otherwise there is no effect.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-unslashed))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-unslashed`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.